### PR TITLE
fix: do not throw for unexpected audio format

### DIFF
--- a/RTN/fetch.py
+++ b/RTN/fetch.py
@@ -289,8 +289,8 @@ def fetch_audio(data: ParsedData, settings: SettingsModel, failed_keys: set) -> 
 
     for audio_format in data.audio:
         category = "trash" if audio_format == "HQ Clean Audio" else "audio"
-        key = audio_map[audio_format]
-        if not settings.custom_ranks[category][key].fetch:
+        key = audio_map.get(audio_format)
+        if key and not settings.custom_ranks[category][key].fetch:
             failed_keys.add(f"{category}_{key}")
             return True
     return False

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -4,6 +4,7 @@ from RTN import parse
 from RTN.fetch import (
     check_fetch,
     check_required,
+    fetch_audio,
     fetch_resolution,
     language_handler,
 )
@@ -47,6 +48,18 @@ def test_fetch_resolution(settings: SettingsModel, raw_title: str, expected: boo
         assert "resolution" in next(iter(failed_keys)), f"Expected resolution in failed keys for {raw_title}"
     else:
         assert not failed_keys, f"Expected no failed keys for {raw_title}"
+
+
+@pytest.mark.parametrize("raw_title, expected, expected_audio", [
+    ("Oppenheimer.2023.2160p.REMUX.IMAX.Dolby.Vision.And.HDR10.PLUS.ENG.ITA.LATINO.DTS-HD.Master.DDP5.1.DV.x265.mkv", False, ["DTS Lossless", "Dolby Digital Plus"]),
+    ("Oppenheimer 2023 Bluray 2160p AV1 HDR10 EN/FR/ES OPUS 5.1-UH", False, ["OPUS"]),
+])
+def test_fetch_audio(settings: SettingsModel, raw_title: str, expected: bool, expected_audio: str):
+    data = parse(raw_title)
+    failed_keys = set()
+    assert data.audio == expected_audio, f"Expected {expected_audio} for {raw_title}"
+    fetch = fetch_audio(data, settings, failed_keys)
+    assert fetch == expected
 
 
 @pytest.mark.parametrize("raw_title, expected, message", [

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -54,7 +54,7 @@ def test_fetch_resolution(settings: SettingsModel, raw_title: str, expected: boo
     ("Oppenheimer.2023.2160p.REMUX.IMAX.Dolby.Vision.And.HDR10.PLUS.ENG.ITA.LATINO.DTS-HD.Master.DDP5.1.DV.x265.mkv", False, ["DTS Lossless", "Dolby Digital Plus"]),
     ("Oppenheimer 2023 Bluray 2160p AV1 HDR10 EN/FR/ES OPUS 5.1-UH", False, ["OPUS"]),
 ])
-def test_fetch_audio(settings: SettingsModel, raw_title: str, expected: bool, expected_audio: str):
+def test_fetch_audio(settings: SettingsModel, raw_title: str, expected: bool, expected_audio: list):
     data = parse(raw_title)
     failed_keys = set()
     assert data.audio == expected_audio, f"Expected {expected_audio} for {raw_title}"


### PR DESCRIPTION
# Pull Request Check List

Resolves: #issue-number-here

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Description:

With the recent changes the parser seems to return formats like e.g. OPUS still, but the fetch logic can't handle audio formats not in that hard-coded array. See, e.g. https://github.com/g0ldyy/comet/issues/275

Sorry, I'm not a python dev and also not fully onboarded here. The test changes don't look to useful for me, but maybe it helps still to reproduce the issue
